### PR TITLE
design: 430px아래로 갈때 카테고리 아이콘 세로정렬 되는 버그 수정

### DIFF
--- a/src/components/signup/hobby/CategorySection.tsx
+++ b/src/components/signup/hobby/CategorySection.tsx
@@ -20,7 +20,7 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
       <h3 className="relative self-stretch text-sm font-semibold leading-5 text-black">
         <span className="text-sm font-bold text-black">{title}</span>
       </h3>
-      <div className="flex relative flex-wrap gap-2 content-center items-center self-stretch max-sm:left-4 max-sm:gap-1.5 max-sm:w-[calc(100%_-_32px)]">
+      <div className="flex flex-wrap gap-2 content-center items-center self-start max-sm:left-4 max-sm:w-[calc(100%_-_32px)]">
         {items.map((item) => (
           <SelectableChip
             key={item}

--- a/src/components/signup/hobby/InterestSelector.tsx
+++ b/src/components/signup/hobby/InterestSelector.tsx
@@ -19,8 +19,8 @@ interface InterestSelectorProps {
 
 export const InterestSelector: React.FC<InterestSelectorProps> = ({ selectedItems, onItemToggle }) => {
   return (
-    <main className="flex absolute flex-col justify-end items-center px-5 pt-4 pb-2 h-[1237px] top-[200px] max-w-[clamp(360px,100vw,430px)] max-sm:px-4 max-sm:pt-4 max-sm:pb-2">
-      <div className="flex absolute flex-col gap-10 items-start h-[1212px] left-[18px] top-[17px] w-[357px] max-sm:left-4 max-sm:gap-1.5 max-sm:w-[calc(100%_-_32px)]">
+    <main className="flex absolute w-full flex-col justify-end items-center px-5 pt-4 pb-2 h-[1237px] top-[200px] max-w-[clamp(360px,100vw,430px)] max-sm:px-4 max-sm:pt-4 max-sm:pb-2">
+      <div className="flex absolute gap-10 flex-col items-start h-[1212px] left-[18px] w-[357px] max-sm:left-4 max-sm:w-[calc(100%_-_32px)]">
         {Object.entries(categories).map(([categoryTitle, items]) => (
           <CategorySection
             key={categoryTitle}

--- a/src/pages/HobbySelectionPage.tsx
+++ b/src/pages/HobbySelectionPage.tsx
@@ -57,7 +57,7 @@ export const HobbySelectionPage: React.FC = () => {
   };
 
   return (
-    <div className="relative mx-auto my-0 bg-white h-[1650px] max-w-[clamp(360px,100vw,430px)]">
+    <div className="relative mx-auto my-0 bg-white h-[1650px] max-w-[clamp(393px,100vw,430px)]">
       <header className="fixed mx-4 top-0 z-40 w-[360px] bg-white pb-28">
         <ProgressBar currentStep={3} />
 


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #13 

## ✏️ Summary
<!-- 개요 -->
아이콘 세로 정렬로 되는 오류 수정

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
아이콘 세로 정렬되는 오류 수정

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes