### PR TITLE
FloatingActionButton 웹에서도 바깥을 벗어나지 않도록 설정

### DIFF
--- a/src/components/common/FloatingActionButton.tsx
+++ b/src/components/common/FloatingActionButton.tsx
@@ -14,13 +14,15 @@ const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ className =
     };
 
     return (
-        <div className={`fixed bottom-[78px] right-[18px] ${className}`}>
-            <button 
-                onClick={handleClick}
-                className="w-[50px] h-[50px] bg-[#F45F3A] rounded-full flex items-center justify-center shadow-lg"
-            >
-                <img src={PlusIcon} alt='플로팅 버튼' />
-            </button>
+        <div className={`fixed bottom-[78px] right-1/2 transform translate-x-[50%] max-w-[430px] w-full ${className}`}>
+            <div className="flex justify-end pr-[18px]">
+                <button 
+                    onClick={handleClick}
+                    className="w-[50px] h-[50px] bg-[#F45F3A] rounded-full flex items-center justify-center shadow-lg"
+                >
+                    <img src={PlusIcon} alt='플로팅 버튼' />
+                </button>
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## 📌 Issue number and Link
#65 

## ✏️ Summary
FloatingActionButton 웹에서도 바깥을 벗어나지 않도록 설정

## 📝 Changes
부모 div의 max 설정 후 translate로 가운데 정렬

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes