### PR TITLE
Feat/#80 채팅목록, 알림창

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import MyProfile from './pages/MyPage/MyProfile'
 import MyHobby from './pages/MyPage/MyHobby'
 import ChatRoom from './pages/chat/ChatRoom'
 import Schedule from './pages/schedule/Schedule'
+import ChatList from './pages/chat/ChatList'
 
 function App() {
 
@@ -43,6 +44,7 @@ function App() {
         <Route path='/myPage/hobby' element={<MyHobby/>} />
         <Route path='/chat' element={<ChatRoom />} />
         <Route path='/schedule' element={<Schedule />} />
+        <Route path='/chat/list' element={<ChatList />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/components/chat/ChatListBox.tsx
+++ b/src/components/chat/ChatListBox.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+interface ChatListBoxProps {
+  name?: string;
+  lastMessage?: string;
+  timestamp?: string;
+  unreadCount?: string;
+  profileImage?: string;
+}
+
+const ChatListBox: React.FC<ChatListBoxProps> = ({
+  name = "name",
+  lastMessage = "마지막 채팅 내용",
+  timestamp = "07/30 14:08",
+  unreadCount = "nn",
+  profileImage
+}) => {
+    return (
+        <div className='flex w-full px-[18px] py-4 items-center gap-5 border-b-[0.5px] border-black-400 h-[82px]'>
+            {/* Profile Image */}
+            <div className='w-[50px] h-[50px] flex-shrink-0 rounded-full bg-black-200 flex items-center justify-center overflow-hidden'>
+                {profileImage ? (
+                    <img 
+                        src={profileImage} 
+                        alt={`${name} 프로필`}
+                        className="w-full h-full rounded-full object-cover"
+                    />
+                ) : (
+                    <svg width="50" height="50" viewBox="0 0 50 50" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <rect width="50" height="50" rx="25" fill="#E9E6E6"/>
+                        <path d="M25 30C26.9968 30 28.9488 29.4135 30.6091 28.3147C32.2694 27.2159 33.5635 25.6541 34.3276 23.8268C35.0918 21.9996 35.2917 19.9889 34.9022 18.0491C34.5126 16.1093 33.551 14.3275 32.1391 12.9289C30.7271 11.5304 28.9281 10.578 26.9697 10.1922C25.0112 9.8063 22.9812 10.0043 21.1364 10.7612C19.2915 11.5181 17.7147 12.7998 16.6054 14.4443C15.496 16.0888 14.9038 18.0222 14.9038 20C14.9038 22.6522 15.9675 25.1957 17.8609 27.0711C19.7543 28.9464 22.3223 30 25 30ZM25 32.8571C18.7422 32.8571 6.25 36.6857 6.25 44.2857V50H43.75V44.2857C43.75 36.6857 31.2578 32.8571 25 32.8571Z" fill="#AFA9A9"/>
+                    </svg>
+                )}
+            </div>
+
+            {/* Chat Content */}
+            <div className='flex justify-end items-start gap-5 flex-1'>
+                <div className='flex flex-col items-start gap-1 flex-1'>
+                    {/* Name */}
+                    <div className='self-stretch text-black font-medium text-base font-sans'>
+                        {name}
+                    </div>
+                    {/* Last Message */}
+                    <div className='self-stretch text-black text-sm font-light leading-[19px] font-sans'>
+                        {lastMessage}
+                    </div>
+                </div>
+
+                {/* Info Section */}
+                <div className='flex flex-col justify-center items-end gap-1'>
+                    {/* Timestamp */}
+                    <div className='text-black font-light text-xs'>
+                        {timestamp}
+                    </div>
+                    {/* Notification Badge */}
+                    <div className='flex h-[18px] px-0 py-[2px] justify-center items-center rounded-full bg-primary-700'>
+                        <div className='w-[30px] flex-shrink-0 text-black-100 text-center font-light text-xs'>
+                            {unreadCount}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ChatListBox;
+    

--- a/src/components/common/BottomNavBar.tsx
+++ b/src/components/common/BottomNavBar.tsx
@@ -5,6 +5,7 @@ import SearchIcon from '../../assets/common/bottom-navbar-search.svg?react';
 import FriendIcon from '../../assets/common/bottom-navbar-friend.svg?react';
 import ChatIcon from '../../assets/common/bottom-navbar-chat.svg?react';
 import ProfileIcon from '../../assets/common/bottom-navbar-profile.svg?react';
+import PlusIcon from '../../assets/common/plus.svg';
 
 interface BottomNavBarProps {
   menu: 'home' | 'search' | 'friend' | 'chat' | 'profile';
@@ -36,8 +37,26 @@ const BottomNavBar: React.FC<BottomNavBarProps> = ({ menu }) => {
     }
   };
 
+  const handleFloatingButtonClick = () => {
+    navigate('/create-meeting');
+  };
+
     return (
-        <div className="fixed bottom-0 left-0 right-0 w-full max-w-[clamp(360px,100vw,430px)] mx-auto bg-white shadow-[0_-1px_0_#AFA9A9] rounded-t-lg">
+        <>
+            {/* Floating Action Button */}
+            <div className="fixed bottom-[78px] right-1/2 transform translate-x-[50%] max-w-[430px] w-full">
+                <div className="flex justify-end pr-[18px]">
+                    <button 
+                        onClick={handleFloatingButtonClick}
+                        className="w-[50px] h-[50px] bg-[#F45F3A] rounded-full flex items-center justify-center shadow-lg"
+                    >
+                        <img src={PlusIcon} alt='플로팅 버튼' />
+                    </button>
+                </div>
+            </div>
+            
+            {/* Bottom Navigation Bar */}
+            <div className="fixed bottom-0 left-0 right-0 w-full max-w-[clamp(360px,100vw,430px)] mx-auto bg-white shadow-[0_-1px_0_#AFA9A9] rounded-t-lg">
             <div className="flex justify-around py-[18px]">
                 <div
                     className="w-6 h-6 flex items-center justify-center cursor-pointer"
@@ -70,7 +89,8 @@ const BottomNavBar: React.FC<BottomNavBarProps> = ({ menu }) => {
                     <ProfileIcon fill={activeTab === 'profile' ? '#F45F3A' : '#AFA9A9'} width={24} height={24} />
                 </div>
             </div>
-        </div>
+            </div>
+        </>
     );
 };
 

--- a/src/components/common/NoFixedHeaderSeoulmate.tsx
+++ b/src/components/common/NoFixedHeaderSeoulmate.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface TopBarProps {
+  title: string;
+  alarm: boolean;
+}
+
+export const NoFixedHeaderSeoulmate: React.FC<TopBarProps> = ({ title, alarm }) => {
+  return (
+    <header className="px-[18px] flex justify-between items-center bg-white h-[60px] w-full max-w-[clamp(360px,100vw,430px)]">
+      <h1 className="text-2xl font-yangjin text-primary-700 cursor-pointer">
+        {title}
+      </h1>
+      <div>
+        {alarm ? <div
+          dangerouslySetInnerHTML={{
+            __html:
+              "<svg id=\"I658:3332;106:650\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\" class=\"alarm-icon\" style=\"display: flex; width: 40px; height: 40px; padding: 8px; justify-content: center; align-items: center; gap: 8px; flex-shrink: 0\"> <path d=\"M12 21.5C12.6193 21.5008 13.2235 21.3086 13.7285 20.9502C14.2335 20.5917 14.6143 20.0849 14.818 19.5H9.182C9.38566 20.0849 9.76648 20.5917 10.2715 20.9502C10.7765 21.3086 11.3807 21.5008 12 21.5ZM19 15.086V10.5C19 7.283 16.815 4.573 13.855 3.758C13.562 3.02 12.846 2.5 12 2.5C11.154 2.5 10.438 3.02 10.145 3.758C7.185 4.574 5 7.283 5 10.5V15.086L3.293 16.793C3.10545 16.9805 3.00006 17.2348 3 17.5V18.5C3 18.7652 3.10536 19.0196 3.29289 19.2071C3.48043 19.3946 3.73478 19.5 4 19.5H20C20.2652 19.5 20.5196 19.3946 20.7071 19.2071C20.8946 19.0196 21 18.7652 21 18.5V17.5C20.9999 17.2348 20.8946 16.9805 20.707 16.793L19 15.086Z\" stroke=\"#1A1A1A\" stroke-width=\"1.5\" stroke-linejoin=\"round\"></path> </svg>",
+          }}
+          className='cursor-pointer'
+        /> : ``}
+      </div>
+    </header>
+  );
+};
+
+export default NoFixedHeaderSeoulmate;

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -23,9 +23,6 @@ const MyPage: React.FC = () => {
       {/* Menu Section */}
       <MenuSection />
 
-      {/* Floating Action Button */}
-      <FloatingActionButton />
-
       {/* Bottom Navigation */}
       <BottomNavBar menu="profile" />
     </div>

--- a/src/pages/MyPage/MyProfile.tsx
+++ b/src/pages/MyPage/MyProfile.tsx
@@ -69,8 +69,6 @@ const MyProfile: React.FC = () => {
         </div>
       </div>
 
-      {/* Floating Action Button */}
-      <FloatingActionButton />
 
       {/* Bottom Navigation */}
       <BottomNavBar menu="profile" />

--- a/src/pages/chat/ChatList.tsx
+++ b/src/pages/chat/ChatList.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import NoFixedHeaderSeoulmate from '../../components/common/NoFixedHeaderSeoulmate';
+import TabMenu from '../../components/common/TabMenu';
+import BottomNavBar from '../../components/common/BottomNavBar';
+import ChatListBox from '../../components/chat/ChatListBox';
+
+const ChatList = () => {
+    const [activeTab, setActiveTab] = useState('그룹 채팅');
+
+    const handleGroupChatClick = () => {
+        setActiveTab('그룹 채팅');
+    };
+
+    const handlePersonalChatClick = () => {
+        setActiveTab('개인 채팅');
+    };
+
+    // 임시 그룹 채팅 데이터
+    const groupChatData = [
+        { name: "서울 맛집 탐방", lastMessage: "다음 주 홍대 맛집 투어 어떠세요?", timestamp: "08/04 15:30", unreadCount: "3" },
+        { name: "한강 피크닉", lastMessage: "날씨 좋으니까 한강에서 만나요!", timestamp: "08/04 14:22", unreadCount: "1" },
+        { name: "언어교환 모임", lastMessage: "오늘 영어 회화 연습 할까요?", timestamp: "08/04 13:15", unreadCount: "5" },
+        { name: "등산 동호회", lastMessage: "이번 주말 북한산 등산 참여하실분?", timestamp: "08/03 18:20", unreadCount: "7" },
+        { name: "요리 클래스", lastMessage: "다음 주 파스타 만들기 수업 신청하세요!", timestamp: "08/03 14:55", unreadCount: "2" },
+        { name: "서울 맛집 탐방", lastMessage: "다음 주 홍대 맛집 투어 어떠세요?", timestamp: "08/04 15:30", unreadCount: "3" },
+        { name: "한강 피크닉", lastMessage: "날씨 좋으니까 한강에서 만나요!", timestamp: "08/04 14:22", unreadCount: "1" },
+        { name: "언어교환 모임", lastMessage: "오늘 영어 회화 연습 할까요?", timestamp: "08/04 13:15", unreadCount: "5" },
+        { name: "등산 동호회", lastMessage: "이번 주말 북한산 등산 참여하실분?", timestamp: "08/03 18:20", unreadCount: "7" },
+        { name: "요리 클래스", lastMessage: "다음 주 파스타 만들기 수업 신청하세요!", timestamp: "08/03 14:55", unreadCount: "2" }
+    ];
+
+    // 임시 개인 채팅 데이터
+    const personalChatData = [
+        { name: "김민수", lastMessage: "안녕하세요! 반갑습니다.", timestamp: "08/04 12:45", unreadCount: "2" },
+        { name: "박지영", lastMessage: "내일 카페에서 만날까요?", timestamp: "08/04 11:30", unreadCount: "1" },
+        { name: "이성훈", lastMessage: "프로젝트 관련해서 논의하고 싶어요", timestamp: "08/03 16:10", unreadCount: "4" },
+        { name: "최유진", lastMessage: "오늘 정말 수고 많았어요~", timestamp: "08/03 13:40", unreadCount: "1" },
+        { name: "독서 모임", lastMessage: "이번 달 책은 '82년생 김지영'입니다", timestamp: "08/03 10:25", unreadCount: "6" }
+    ];
+
+    return (
+        <div className='flex flex-col h-screen bg-white'>
+            <NoFixedHeaderSeoulmate title="서울메이트" alarm={false}/>
+            <TabMenu
+                firstTabText="그룹 채팅"
+                secondTabText="개인 채팅"
+                activeTab={activeTab}
+                onFirstTabClick={handleGroupChatClick}
+                onSecondTabClick={handlePersonalChatClick}
+            />
+            
+            <div className="flex-1 overflow-y-auto pb-[60px]">
+                {activeTab === '그룹 채팅' ? (
+                    <div>
+                        {groupChatData.map((chat, index) => (
+                            <ChatListBox
+                                key={index}
+                                name={chat.name}
+                                lastMessage={chat.lastMessage}
+                                timestamp={chat.timestamp}
+                                unreadCount={chat.unreadCount}
+                            />
+                        ))}
+                    </div>
+                ) : (
+                    <div>
+                        {personalChatData.map((chat, index) => (
+                            <ChatListBox
+                                key={index}
+                                name={chat.name}
+                                lastMessage={chat.lastMessage}
+                                timestamp={chat.timestamp}
+                                unreadCount={chat.unreadCount}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+            
+            <BottomNavBar
+                menu="chat"
+            />
+        </div>
+    );
+};
+
+export default ChatList;

--- a/src/pages/search/SearchHobby.tsx
+++ b/src/pages/search/SearchHobby.tsx
@@ -48,8 +48,6 @@ const SearchHobby: React.FC = () => {
             )}
             
 
-            {/* FAB 플러스 버튼 */}
-            <FloatingActionButton/>
 
             {/* 하단 네비게이션바 */}
             <BottomNavBar menu="search"/>


### PR DESCRIPTION
## 📌 Issue number and Link
close #80 
## ✏️ Summary
채팅목록, 알림창 페이지 구현
바텀바에 플로팅 액션버튼 통합

## 📝 Changes
채팅목록, 알림창 페이지 구현
바텀바에 플로팅 액션버튼 통합

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 채팅 목록 페이지가 추가되어 그룹 채팅과 개인 채팅을 탭으로 구분해 확인할 수 있습니다.
  * 채팅 목록에서 각 채팅방의 이름, 최근 메시지, 시간, 안 읽은 메시지 수, 프로필 이미지를 한눈에 볼 수 있습니다.
  * 고정되지 않은 헤더 컴포넌트가 추가되어 제목과 알림 아이콘을 표시할 수 있습니다.
  * 하단 네비게이션 바 위에 새로운 플로팅 액션 버튼이 추가되어 미팅 생성 페이지로 바로 이동할 수 있습니다.

* **기존 기능 변경**
  * 마이페이지, 마이프로필, 취미 검색 페이지에서 플로팅 액션 버튼이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->