### PR TITLE
Fix/#133 ios zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>
   <body>


### PR DESCRIPTION
## 📌 Issue number and Link

#133 

## ✏️ Summary

Fix: IOS 확대 방지 최대 확대 비율 1로 고정

## 📝 Changes

Fix: IOS 확대 방지 최대 확대 비율 1로 고정

## 🔎 PR Type

<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature

- [x] Bugfix

- [ ] Code style update (formatting, local variables)

- [ ] Refactoring

- [ ] infrastructure related changes (CI/CD, Build)

- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 모바일 뷰포트 설정에 maximum-scale=1.0을 적용했습니다. 이제 모바일에서 핀치 줌으로 페이지가 확대되지 않아 레이아웃 흔들림과 의도치 않은 확대 트리거를 방지하고, 초기 표시 비율을 일관되게 유지합니다. 이로써 콘텐츠 가독성과 터치 타깃 정렬이 보다 안정적으로 유지되며, 전반적인 화면 표시가 예측 가능해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->