### PR TITLE
Fix: 검색페이지에서 카테고리 border 잘림 문제

### DIFF
--- a/src/components/search/ActiveSearchClub.tsx
+++ b/src/components/search/ActiveSearchClub.tsx
@@ -144,7 +144,7 @@ const ActiveSearchClub = ({ searchValue = '' }: ActiveSearchClubProps) => {
                     )}
                 </div>
                 <div className="px-[18px] py-5 bg-white">
-                    <div className="flex space-x-3 overflow-x-auto snap-x snap-proximity scrollbar-hide">
+                    <div className="flex space-x-3 overflow-x-auto overflow-y-visible snap-x snap-proximity scrollbar-hide">
                         {categories.map((category) => (
                             <motion.button
                                 key={category.name}


### PR DESCRIPTION

## ✏️ Summary
Fix: 검색페이지에서 카테고리 border 잘림 문제

## 📝 Changes
y 길이를 overflow - y- visible로 수정 
## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes