### PR TITLE
fix: border 잘림 

### DIFF
--- a/src/components/search/ActiveSearchClub.tsx
+++ b/src/components/search/ActiveSearchClub.tsx
@@ -143,7 +143,7 @@ const ActiveSearchClub = ({ searchValue = '' }: ActiveSearchClubProps) => {
                         </div>
                     )}
                 </div>
-                <div className="px-[18px] py-5 bg-white overflow-visible">
+                <div className="px-[18px] py-5 bg-white">
                     <div className="flex space-x-3 overflow-x-auto snap-x snap-proximity scrollbar-hide">
                         {categories.map((category) => (
                             <motion.button
@@ -157,6 +157,7 @@ const ActiveSearchClub = ({ searchValue = '' }: ActiveSearchClubProps) => {
                                         ? 'bg-[#FFE2DB] border-gray-700'
                                         : 'bg-black-100 border-black-400'
                                 }`}
+                                style={{backfaceVisibility:'hidden'}}
                                 initial={false}
                                 animate={{
                                     opacity: selectedCategory === category.name ? 1 : 0.7


### PR DESCRIPTION

## 📌 Issue number and Link
#128 
## ✏️ Summary
border 아랫부분 짤리는 버그 수정

## 📝 Changes
-webkit-backface-visibility: hidden; 추가로 아이폰 자체의 문제 해결 시도
## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 카테고리 필터 영역의 오버플로우 처리 방식을 조정해 요소가 영역 밖으로 보이던 상황을 줄이고, 스크롤/클리핑 동작과 레이아웃 일관성을 개선했습니다.
  - 카테고리 버튼의 렌더링을 최적화하여 애니메이션 중 발생할 수 있는 깜빡임·깨짐 등의 시각적 노이즈를 완화하고 전환의 부드러움과 안정성을 높였습니다.
  - 표시 및 레이아웃 관련 변경으로, 데이터나 기능 동작에는 영향을 주지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->