### PR TITLE
모달창 바깥 쪽 스크롤 되는 현상 수정

### DIFF
--- a/src/components/modal/FriendsModal.tsx
+++ b/src/components/modal/FriendsModal.tsx
@@ -42,19 +42,33 @@ export const FriendsModal: React.FC<FriendsModalProps> = ({
   };
 
   useEffect(() => {
+    const preventScroll = (e: TouchEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        e.preventDefault(); // 모달 바깥쪽 스크롤 차단
+      }
+    };
+
     if (isVisible) {
       document.body.style.overflow = "hidden";
-      document.body.style.touchAction = "none";
+      document.body.style.position = "fixed"; // 모바일에서 스크롤 고정
+      document.body.style.width = "100%";
+
+      document.addEventListener("touchmove", preventScroll, { passive: false });
     } else {
       document.body.style.overflow = "";
-      document.body.style.touchAction = "";
+      document.body.style.position = "";
+      document.body.style.width = "";
+      document.removeEventListener("touchmove", preventScroll);
     }
 
     return () => {
       document.body.style.overflow = "";
-      document.body.style.touchAction = "";
+      document.body.style.position = "";
+      document.body.style.width = "";
+      document.removeEventListener("touchmove", preventScroll);
     };
   }, [isVisible]);
+
 
   useEffect(() => {
     const modalEl = modalRef.current;


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #136 

## ✏️ Summary
<!-- 개요 -->
모달창 바깥 쪽 스크롤 되는 현상 발생

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
e.preventDefault(); 추가

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 모바일 환경에서 모달이 표시될 때 배경 화면이 스크롤되는 문제를 방지하여, 대부분의 모바일 브라우저에서 모달 상호작용 중 화면이 안정적으로 고정되도록 개선했습니다.
  * 모달 외부 영역을 터치·드래그할 때 발생하던 의도치 않은 배경 스크롤을 차단하고, 모달 콘텐츠 내부 스크롤은 정상적으로 동작하도록 보장했습니다.
  * 모달을 닫거나 화면을 이탈할 때 스크롤 상태(화면 위치와 레이아웃)가 정상적으로 복원되도록 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->