### PR TITLE
fix: 모달창 바깥 쪽 스크롤 현상 수정

### DIFF
--- a/src/components/modal/FriendsModal.tsx
+++ b/src/components/modal/FriendsModal.tsx
@@ -50,13 +50,11 @@ export const FriendsModal: React.FC<FriendsModalProps> = ({
 
     if (isVisible) {
       document.body.style.overflow = "hidden";
-      document.body.style.position = "fixed"; // 모바일에서 스크롤 고정
       document.body.style.width = "100%";
 
       document.addEventListener("touchmove", preventScroll, { passive: false });
     } else {
       document.body.style.overflow = "";
-      document.body.style.position = "";
       document.body.style.width = "";
       document.removeEventListener("touchmove", preventScroll);
     }


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #136 

## ✏️ Summary
<!-- 개요 -->
모달창 바깥 쪽 스크롤 되는 현상 발생

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
e.preventDefault(); 추가

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 모바일에서 친구 모달 표시 중 배경 스크롤이 발생하던 문제를 해결하여 의도치 않은 화면 이동을 방지했습니다.
  - 모달 외부 영역에서의 터치 스크롤을 차단해 모달 내부 상호작용의 안정성을 높였습니다.
  - 스クロール 잠금 시 본문 너비를 고정해 레이아웃 흔들림(점프)을 최소화했습니다.
  - 모달을 닫을 때 페이지 스크롤 및 레이아웃 상태가 정상적으로 복원되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->