### PR TITLE
Fix: DateField 및 TimeField 컴포넌트에서 placeholder 색 변경

### DIFF
--- a/src/components/createMeeting/DateField.tsx
+++ b/src/components/createMeeting/DateField.tsx
@@ -24,8 +24,9 @@ export const DateField: React.FC<DateFieldProps> = ({ value = '', onChange }) =>
           }}
           dateFormat="yyyy-MM-dd"
           placeholderText="모임 날짜를 입력하세요."
-          className="self-stretch my-auto text-black-700 bg-transparent border-none outline-none w-full cursor-pointer text-left text-black-300"
+          className="self-stretch my-auto text-black-700 bg-transparent border-none outline-none w-full cursor-pointer text-left"
           locale={ko} // 한국어 로케일 적용
+          customInput={<input className="self-stretch my-auto text-black-700 bg-transparent border-none outline-none w-full cursor-pointer text-left placeholder:text-[#D4D0D0]" />}
         />
       </div>
     </div>

--- a/src/components/createMeeting/TimeField.tsx
+++ b/src/components/createMeeting/TimeField.tsx
@@ -26,7 +26,7 @@ export const TimeField: React.FC<TimeFieldProps> = ({ value = '', onChange }) =>
           dateFormat="HH:mm"
           timeFormat="HH:mm"
           placeholderText="모임 시간을 선택하세요."
-          className="self-stretch my-auto text-black-700 bg-transparent border-none outline-none w-full cursor-pointer text-left text-black-300"
+          customInput={<input className="self-stretch my-auto text-black-700 bg-transparent border-none outline-none w-full cursor-pointer text-left placeholder:text-[#D4D0D0]" />}
         />
       </div>
     </div>


### PR DESCRIPTION
## 📌 Issue number and Link
#128 
## ✏️ Summary
Fix: DateField 및 TimeField 컴포넌트에서 placeholder 색 변경

## 📝 Changes
Fix: DateField 및 TimeField 컴포넌트에서 placeholder 색 변경

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 날짜·시간 입력 필드에 커스텀 입력 UI 적용: 전체 너비, 투명 배경, 테두리/포커스 외곽선 제거, 좌측 정렬, 클릭 가능한 커서.
  - 플레이스홀더 색상을 연한 톤으로 통일해 가독성 개선.
  - 기본 텍스트 색상 조정으로 시각적 일관성 강화.
  - 동작은 동일: 날짜는 yyyy-MM-dd, 시간은 HH:mm 형식으로 표시·전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->