### PR TITLE
Fix: FilterPage 컴포넌트의 스타일을 수정하여 높이를 100dvh로 설정

### DIFF
--- a/src/pages/search/FilterPage.tsx
+++ b/src/pages/search/FilterPage.tsx
@@ -43,7 +43,7 @@ const FilterPage: React.FC = () => {
   };
 
   return (
-    <div className="bg-white h-screen flex flex-col">
+    <div className="bg-white flex flex-col" style={{ height: '100vh' }}>
       <HeaderDetail title="필터" alarm={false} onBackClick={handleBackClick} />
       <div className="mt-[60px] bg-white px-[18px] py-[20px] flex flex-col gap-10 flex-1">
         <LevelSlider


### PR DESCRIPTION
## 📌 Issue number and Link
#128 

## ✏️ Summary
Fix: FilterPage 컴포넌트의 스타일을 수정하여 높이를 100dvh로 설정

## 📝 Changes
Fix: FilterPage 컴포넌트의 스타일을 수정하여 높이를 100dvh로 설정

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 검색 필터 페이지의 최상위 컨테이너 높이 계산 방식을 조정하여 전체 화면 기준으로 레이아웃을 표시합니다. 다양한 디바이스와 브라우저에서도 페이지가 화면을 꽉 채워 보입니다. 기존 뒤로 가기, 상태 업데이트, 하위 컴포넌트 동작에는 변화가 없으며, 스크롤 동작과 시각적 구조, 콘텐츠 배치도 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->