### PR TITLE
feat: 기존 회원 바로 홈페이지 navigate하도록 추가

### DIFF
--- a/src/pages/signUp/AuthRedirect.tsx
+++ b/src/pages/signUp/AuthRedirect.tsx
@@ -18,17 +18,6 @@ export default function AuthRedirect() {
             return;
         }
 
-        // 2. 회원가입 시작된 사용자만 in-progress 확인
-        const inProgressRes = await api.get("/signup/in-progress", { withCredentials: true });
-        const inProgressData = inProgressRes.data.data;
-
-        if (inProgressData.univVerification === "verified") {
-            navigate("/signUp/wait");
-        } else if (inProgressData.univVerification === "SUBMITTED") {
-            navigate("/home");
-        } else {
-            navigate("/home");
-        }
         } catch (err) {
         console.error(err);
         navigate("/"); // 에러 시 홈

--- a/src/pages/signUp/SignUpProfilePage.tsx
+++ b/src/pages/signUp/SignUpProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ProgressBar } from "../../components/signup/ProgressBar";
 import { ProfileImageUpload } from "../../components/signup/profile/ProfileImageUpload";
 import { FormField } from "../../components/signup/profile/FormField";
@@ -26,6 +26,29 @@ export const SignUpProfilePage: React.FC = () => {
   const navigate = useNavigate();
   const [profileFile, setProfileFile] = useState<File | null>(null);
   const [birthDate, setBirthDate] = useState<Date | null>(null);
+
+  useEffect(() => {
+    const checkInProgress = async () => {
+      try {
+        // 2. 회원가입 시작된 사용자만 in-progress 확인
+        const inProgressRes = await api.get("/signup/in-progress");
+        const inProgressData = inProgressRes.data.data;
+
+        if (inProgressData.univVerification === "VERIFIED") {
+            navigate("/signUp/wait");
+        } else if (inProgressData.univVerification === "SUBMITTED") {
+            navigate("/home");
+        } else {
+            navigate("/home");
+        }
+      } catch (err) {
+        console.error(err);
+        navigate("/"); // 에러 시 홈
+      }
+    };
+
+    checkInProgress();
+  }, [navigate]);
 
   const [formData, setFormData] = useState<FormData>({
     lastName: '',


### PR DESCRIPTION
## 📌 Issue number and Link
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  closed #168 

## ✏️ Summary
<!-- 개요 -->
기존회원 시 홈페이지 이동

## 📝 Changes
<!-- 작업 사항 및 변경로직 -->
기존회원 시 홈페이지 이동 추가

## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 회원가입 프로필 페이지 진입 시 대학교 인증 상태를 자동 확인하고 리다이렉트: 인증 완료 → /signUp/wait, 그 외 → /home. 오류 시 루트(/)로 이동.

* 리팩터링
  * AuthRedirect의 진행 상태 기반 내비게이션을 제거하여 흐름 단순화. 초기 프로필 정보 확인 후 /signUp/profile 리다이렉트만 유지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->